### PR TITLE
Add Aryan Kargwal profile

### DIFF
--- a/src/people/aryan-kargwal.md
+++ b/src/people/aryan-kargwal.md
@@ -1,0 +1,23 @@
+---
+name: Aryan Kargwal
+role: phd
+title: PhD Student
+short_bio: Researches semantic SLAM and formal verification for autonomous multi-robot systems.
+supervisor: Pierre-Yves Lajoie
+tags: [Semantic SLAM, Formal Verification, Multi-Robot Systems]
+github: aryankargwal
+order: 99
+---
+
+Aryan Kargwal is a PhD student at Polytechnique Montréal. His research focuses
+on building trustworthy spatial-intelligence systems for autonomous robot teams
+by combining semantic mapping with formal verification.
+
+## Research Interests
+
+- **Semantic SLAM** — enabling robots to build maps that represent objects and
+  their meaning in addition to geometry.
+- **Formal verification** — testing whether learned world models remain
+  consistent and reliable in dynamic environments.
+- **Multi-robot systems** — developing methods for autonomous robot teams to
+  understand and operate in shared environments.


### PR DESCRIPTION
## Summary

- add Aryan Kargwal to the PhD Students section
- list Pierre-Yves Lajoie as supervisor
- add research interests in semantic SLAM, formal verification, and multi-robot systems
- link Aryan's GitHub profile

## Why

This adds a profile page and team card for a new PhD student in the MIST Lab website.

## Validation

- `npm run build`
- confirmed Eleventy generated `/people/aryan-kargwal/` and the People-page student card

## Before review

- confirm the biography and research wording
- add a preferred profile photo and optional contact links
